### PR TITLE
build: remove integration tests running in main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.head_branch == 'release' || github.event.workflow_run.head_branch == 'main'
+    if: github.event.workflow_run.head_branch == 'release'
     steps:
       - uses: actions/checkout@v4
       - name: Rodar testes de integração


### PR DESCRIPTION
Modificado:

release.yaml - condicional dos testes de integração roda apenas na branch "release", removando a main apenas para produção.