### PR TITLE
build: change pom to fix jacoco report output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,6 @@
         <version>0.8.10</version>
         <executions>
           <execution>
-            <id>prepare-agent</id>
             <goals>
               <goal>prepare-agent</goal>
             </goals>
@@ -110,11 +109,6 @@
             <goals>
               <goal>report</goal>
             </goals>
-            <configuration>
-              <formats>
-                <format>XML</format>
-              </formats>
-            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Modificado:

pom.xml, para retirada de configuração que limitava a saída de relatórios do jacoco.